### PR TITLE
Order cancel fix

### DIFF
--- a/Plugin/Quote/Address/Total/Shipping.php
+++ b/Plugin/Quote/Address/Total/Shipping.php
@@ -128,7 +128,7 @@ class Shipping
      */
     private function processTotal(Quote $quote, Quote\Address\Total $total, $rate, $address)
     {
-        $fee         = $this->getFee();
+        $fee         = $this->getFee($quote);
         $store       = $quote->getStore();
         $amountPrice = $this->priceCurrency->convert(
             $rate->getPrice() + $fee,
@@ -144,11 +144,12 @@ class Shipping
     }
 
     /**
+     * @param Quote $quote
      * @return float
      */
-    private function getFee()
+    private function getFee($quote)
     {
-        $order = $this->currentPostNLOrder->get();
+        $order = $this->currentPostNLOrder->get($quote->getQuoteId());
 
         if (!$order) {
             return 0;

--- a/Plugin/Quote/Address/Total/Shipping.php
+++ b/Plugin/Quote/Address/Total/Shipping.php
@@ -149,7 +149,7 @@ class Shipping
      */
     private function getFee($quote)
     {
-        $order = $this->currentPostNLOrder->get($quote->getQuoteId());
+        $order = $this->currentPostNLOrder->get($quote->getId());
 
         if (!$order) {
             return 0;

--- a/Service/Order/CurrentPostNLOrder.php
+++ b/Service/Order/CurrentPostNLOrder.php
@@ -69,11 +69,15 @@ class CurrentPostNLOrder
     }
 
     /**
+     * @param int $quoteId
      * @return PostNLOrder|null
      */
-    public function get()
+    public function get($quoteId = null)
     {
-        $searchCriteria = $this->searchCriteriaBuilder->addFilter('quote_id', $this->getQuoteId());
+        if (!$quoteId) {
+            $quoteId = $this->getQuoteId();
+        }
+        $searchCriteria = $this->searchCriteriaBuilder->addFilter('quote_id', $quoteId);
         $searchCriteria->setPageSize(1);
 
         /** @var \Magento\Framework\Api\SearchResults $list */


### PR DESCRIPTION
To replicate the issue:
Login to website,
add product to cart, 
go to checkout
select PostNl for shipment, Buckaroo Ideal for payment,
click on place order button
in Buckaroo click on cancel button
Expected result:
Customer is redirected back to checkout
Actual result:
Customer can't be redirected to website, 500 error is show. If go back to website can't login to account any more, can't add any product to the shopping cart.
Errors on customer account page:
Fatal error: Maximum function nesting level of '256' reached, aborting! in .../vendor/magento/framework/Data/Collection.php on line 106
Call Stack
Time	Memory	Function	Location
1	0.0004	369304	{main}
( )	.../index.php:0
2	0.4178	7247768	Magento\Framework\App\Bootstrap->run( )	.../index.php:37
3	0.4199	7289384	Magento\Framework\App\Http->launch( )	.../Bootstrap.php:258
Reason:
PostNl extension loads customer quote in a loop
