### PR TITLE
Check against selectedOption().data in isRowSelected

### DIFF
--- a/view/frontend/web/js/Renderer/DeliveryOptions/Pickup.js
+++ b/view/frontend/web/js/Renderer/DeliveryOptions/Pickup.js
@@ -223,7 +223,7 @@ define([
          * @returns {boolean}
          */
         isRowSelected: function ($data) {
-            return JSON.stringify(this.selectedOption()) == JSON.stringify($data);
+            return this.selectedOption() && JSON.stringify(this.selectedOption().data) == JSON.stringify($data);
         }
     });
 });


### PR DESCRIPTION
The `isRowSelected()` method called with the `pickupAddress` as `$data`. It got checked against `selectedOption()` which has the data wrapped in `selectedOption().data`, so the check should be against the wrapped data.