### PR TITLE
isSundaySortingAllowed also checks on saturday

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -122,7 +122,8 @@ class Data extends AbstractHelper
     public function isSundaySortingAllowed()
     {
         $shipmentDays = explode(',', $this->webshop->getShipmentDays());
-        return !empty(array_intersect(['0', '6', '7'], $shipmentDays)) ? 'true' : 'false';
+        
+        return in_array('0', $shipmentDays);
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -123,7 +123,7 @@ class Data extends AbstractHelper
     {
         $shipmentDays = explode(',', $this->webshop->getShipmentDays());
         
-        return in_array('0', $shipmentDays);
+        return in_array('0', $shipmentDays) ? 'true' : 'false';
     }
 
     /**


### PR DESCRIPTION
The isSundaySortingAllowed function checks if sunday is selected in the config. But also checks on key '6' and '7', so according to the WeekDays config provider sunday is always '0'. 

Now if clients have saturday sorting selected in backend also sunday is allowed and will be used for ship_at date, which is not correct This will fix it.  

'7' is never used, so removed.