### PR TITLE
Improve PdfCustomiser integration

### DIFF
--- a/Service/Shipment/Packingslip/Compatibility/FoomanPdfCustomiser.php
+++ b/Service/Shipment/Packingslip/Compatibility/FoomanPdfCustomiser.php
@@ -29,6 +29,7 @@
  * @copyright   Copyright (c) Total Internet Group B.V. https://tig.nl/copyright
  * @license     http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
  */
+
 namespace TIG\PostNL\Service\Shipment\Packingslip\Compatibility;
 
 use Magento\Sales\Api\OrderRepositoryInterface;
@@ -87,13 +88,7 @@ class FoomanPdfCustomiser
      */
     public function getPdf(Factory $factory, ShipmentInterface $magentoShipment)
     {
-        if ($this->scopeConfig->isSetFlag('sales_pdf/shipment/shipmentuseorder')) {
-            $orderId = $magentoShipment->getOrderId();
-            $order = $this->orderRepository->get($orderId);
-            $document = $this->orderShipmentFactoryProxy->create(['data' => ['order' => $order]]);
-        } else {
-            $document = $this->shipmentFactoryProxy->create(['data' => ['shipment' => $magentoShipment]]);
-        }
+        $document = $this->getPdfDocument($magentoShipment);
         /** @var \Fooman\PdfCore\Model\PdfRenderer $pdfRenderer */
         $pdfRenderer = $this->pdfRendererFactoryProxy->create();
 
@@ -106,5 +101,20 @@ class FoomanPdfCustomiser
         $factory->setY(500);
 
         return $pdfRenderer->getPdfAsString();
+    }
+
+    /**
+     * @param ShipmentInterface $magentoShipment
+     *
+     * @return \Fooman\PdfCustomiser\Block\OrderShipment|\Fooman\PdfCustomiser\Block\Shipment
+     */
+    private function getPdfDocument(ShipmentInterface $magentoShipment)
+    {
+        if ($this->scopeConfig->isSetFlag('sales_pdf/shipment/shipmentuseorder')) {
+            $orderId = $magentoShipment->getOrderId();
+            $order = $this->orderRepository->get($orderId);
+            return $this->orderShipmentFactoryProxy->create(['data' => ['order' => $order]]);
+        }
+        return $this->shipmentFactoryProxy->create(['data' => ['shipment' => $magentoShipment]]);
     }
 }

--- a/Service/Shipment/Packingslip/Compatibility/FoomanPdfCustomiser.php
+++ b/Service/Shipment/Packingslip/Compatibility/FoomanPdfCustomiser.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ *
+ *          ..::..
+ *     ..::::::::::::..
+ *   ::'''''':''::'''''::
+ *   ::..  ..:  :  ....::
+ *   ::::  :::  :  :   ::
+ *   ::::  :::  :  ''' ::
+ *   ::::..:::..::.....::
+ *     ''::::::::::::''
+ *          ''::''
+ *
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Creative Commons License.
+ * It is available through the world-wide-web at this URL:
+ * http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to servicedesk@tig.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact servicedesk@tig.nl for more information.
+ *
+ * @copyright   Copyright (c) Total Internet Group B.V. https://tig.nl/copyright
+ * @license     http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ */
+namespace TIG\PostNL\Service\Shipment\Packingslip\Compatibility;
+
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Api\Data\ShipmentInterface;
+use TIG\PostNL\Service\Shipment\Packingslip\Factory;
+use Magento\Framework\Exception\NotFoundException;
+
+class FoomanPdfCustomiser
+{
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var OrderShipmentFactoryProxy
+     */
+    private $orderShipmentFactoryProxy;
+
+    /**
+     * @var ShipmentFactoryProxy
+     */
+    private $shipmentFactoryProxy;
+
+    /**
+     * @var PdfRendererFactoryProxy
+     */
+    private $pdfRendererFactoryProxy;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        ScopeConfigInterface $scopeConfig,
+        OrderShipmentFactoryProxy $orderShipmentFactoryProxy,
+        ShipmentFactoryProxy $shipmentFactoryProxy,
+        PdfRendererFactoryProxy $pdfRendererFactoryProxy
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->scopeConfig = $scopeConfig;
+        $this->orderShipmentFactoryProxy = $orderShipmentFactoryProxy;
+        $this->shipmentFactoryProxy = $shipmentFactoryProxy;
+        $this->pdfRendererFactoryProxy = $pdfRendererFactoryProxy;
+    }
+
+    /**
+     * @param Factory $factory
+     * @param ShipmentInterface $magentoShipment
+     *
+     * @return string
+     * @throws NotFoundException
+     */
+    public function getPdf(Factory $factory, ShipmentInterface $magentoShipment)
+    {
+        if ($this->scopeConfig->isSetFlag('sales_pdf/shipment/shipmentuseorder')) {
+            $orderId = $magentoShipment->getOrderId();
+            $order = $this->orderRepository->get($orderId);
+            $document = $this->orderShipmentFactoryProxy->create(['data' => ['order' => $order]]);
+        } else {
+            $document = $this->shipmentFactoryProxy->create(['data' => ['shipment' => $magentoShipment]]);
+        }
+        /** @var \Fooman\PdfCore\Model\PdfRenderer $pdfRenderer */
+        $pdfRenderer = $this->pdfRendererFactoryProxy->create();
+
+        $pdfRenderer->addDocument($document);
+
+        if (!$pdfRenderer->hasPrintContent()) {
+            throw new NotFoundException(__('Nothing to print'));
+        }
+
+        $factory->setY(500);
+
+        return $pdfRenderer->getPdfAsString();
+    }
+}

--- a/Service/Shipment/Packingslip/Compatibility/OrderShipmentFactoryProxy.php
+++ b/Service/Shipment/Packingslip/Compatibility/OrderShipmentFactoryProxy.php
@@ -33,6 +33,7 @@ namespace TIG\PostNL\Service\Shipment\Packingslip\Compatibility;
 
 use Magento\Framework\ObjectManagerInterface;
 
+// @codingStandardsIgnoreFile
 class OrderShipmentFactoryProxy
 {
 

--- a/Service/Shipment/Packingslip/Compatibility/OrderShipmentFactoryProxy.php
+++ b/Service/Shipment/Packingslip/Compatibility/OrderShipmentFactoryProxy.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ *
+ *          ..::..
+ *     ..::::::::::::..
+ *   ::'''''':''::'''''::
+ *   ::..  ..:  :  ....::
+ *   ::::  :::  :  :   ::
+ *   ::::  :::  :  ''' ::
+ *   ::::..:::..::.....::
+ *     ''::::::::::::''
+ *          ''::''
+ *
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Creative Commons License.
+ * It is available through the world-wide-web at this URL:
+ * http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to servicedesk@tig.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact servicedesk@tig.nl for more information.
+ *
+ * @copyright   Copyright (c) Total Internet Group B.V. https://tig.nl/copyright
+ * @license     http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ */
+namespace TIG\PostNL\Service\Shipment\Packingslip\Compatibility;
+
+use Magento\Framework\ObjectManagerInterface;
+
+class OrderShipmentFactoryProxy
+{
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var \Fooman\PdfCustomiser\Block\OrderShipmentFactory
+     */
+    private $subject;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * @return \Fooman\PdfCustomiser\Block\OrderShipmentFactory
+     */
+    private function getSubject()
+    {
+        if (!$this->subject) {
+            $this->subject = $this->objectManager->get(\Fooman\PdfCustomiser\Block\OrderShipmentFactory::class);
+        }
+        return $this->subject;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return \Fooman\PdfCustomiser\Block\OrderShipment
+     */
+    public function create(array $data = [])
+    {
+        return $this->getSubject()->create($data);
+    }
+}

--- a/Service/Shipment/Packingslip/Compatibility/PdfRendererFactoryProxy.php
+++ b/Service/Shipment/Packingslip/Compatibility/PdfRendererFactoryProxy.php
@@ -33,6 +33,7 @@ namespace TIG\PostNL\Service\Shipment\Packingslip\Compatibility;
 
 use Magento\Framework\ObjectManagerInterface;
 
+// @codingStandardsIgnoreFile
 class PdfRendererFactoryProxy
 {
 
@@ -49,6 +50,7 @@ class PdfRendererFactoryProxy
     /**
      * @param ObjectManagerInterface $objectManager
      */
+    // @codingStandardsIgnoreLine
     public function __construct(ObjectManagerInterface $objectManager)
     {
         $this->objectManager = $objectManager;

--- a/Service/Shipment/Packingslip/Compatibility/PdfRendererFactoryProxy.php
+++ b/Service/Shipment/Packingslip/Compatibility/PdfRendererFactoryProxy.php
@@ -50,7 +50,6 @@ class PdfRendererFactoryProxy
     /**
      * @param ObjectManagerInterface $objectManager
      */
-    // @codingStandardsIgnoreLine
     public function __construct(ObjectManagerInterface $objectManager)
     {
         $this->objectManager = $objectManager;

--- a/Service/Shipment/Packingslip/Compatibility/PdfRendererFactoryProxy.php
+++ b/Service/Shipment/Packingslip/Compatibility/PdfRendererFactoryProxy.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ *
+ *          ..::..
+ *     ..::::::::::::..
+ *   ::'''''':''::'''''::
+ *   ::..  ..:  :  ....::
+ *   ::::  :::  :  :   ::
+ *   ::::  :::  :  ''' ::
+ *   ::::..:::..::.....::
+ *     ''::::::::::::''
+ *          ''::''
+ *
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Creative Commons License.
+ * It is available through the world-wide-web at this URL:
+ * http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to servicedesk@tig.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact servicedesk@tig.nl for more information.
+ *
+ * @copyright   Copyright (c) Total Internet Group B.V. https://tig.nl/copyright
+ * @license     http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ */
+namespace TIG\PostNL\Service\Shipment\Packingslip\Compatibility;
+
+use Magento\Framework\ObjectManagerInterface;
+
+class PdfRendererFactoryProxy
+{
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var \Fooman\PdfCore\Model\PdfRendererFactory
+     */
+    private $subject;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * @return \Fooman\PdfCore\Model\PdfRendererFactory
+     */
+    private function getSubject()
+    {
+        if (!$this->subject) {
+            $this->subject = $this->objectManager->get(\Fooman\PdfCore\Model\PdfRendererFactory::class);
+        }
+        return $this->subject;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return \Fooman\PdfCore\Model\PdfRendererFactory
+     */
+    public function create(array $data = [])
+    {
+        return $this->getSubject()->create($data);
+    }
+}

--- a/Service/Shipment/Packingslip/Compatibility/ShipmentFactoryProxy.php
+++ b/Service/Shipment/Packingslip/Compatibility/ShipmentFactoryProxy.php
@@ -33,6 +33,7 @@ namespace TIG\PostNL\Service\Shipment\Packingslip\Compatibility;
 
 use Magento\Framework\ObjectManagerInterface;
 
+// @codingStandardsIgnoreFile
 class ShipmentFactoryProxy
 {
 

--- a/Service/Shipment/Packingslip/Compatibility/ShipmentFactoryProxy.php
+++ b/Service/Shipment/Packingslip/Compatibility/ShipmentFactoryProxy.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ *
+ *          ..::..
+ *     ..::::::::::::..
+ *   ::'''''':''::'''''::
+ *   ::..  ..:  :  ....::
+ *   ::::  :::  :  :   ::
+ *   ::::  :::  :  ''' ::
+ *   ::::..:::..::.....::
+ *     ''::::::::::::''
+ *          ''::''
+ *
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Creative Commons License.
+ * It is available through the world-wide-web at this URL:
+ * http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to servicedesk@tig.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact servicedesk@tig.nl for more information.
+ *
+ * @copyright   Copyright (c) Total Internet Group B.V. https://tig.nl/copyright
+ * @license     http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ */
+namespace TIG\PostNL\Service\Shipment\Packingslip\Compatibility;
+
+use Magento\Framework\ObjectManagerInterface;
+
+class ShipmentFactoryProxy
+{
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var \Fooman\PdfCustomiser\Block\OrderShipmentFactory
+     */
+    private $subject;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * @return \Fooman\PdfCustomiser\Block\ShipmentFactory
+     */
+    private function getSubject()
+    {
+        if (!$this->subject) {
+            $this->subject = $this->objectManager->get(\Fooman\PdfCustomiser\Block\ShipmentFactoryProxy::class);
+        }
+        return $this->subject;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return \Fooman\PdfCustomiser\Block\Shipment
+     */
+    public function create(array $data = [])
+    {
+        return $this->getSubject()->create($data);
+    }
+}


### PR DESCRIPTION
Great job on integrating with our extension. Below a couple of suggestions to improve it:

1.) the module check only needs to happen on PdfCustomiser. PrintOrderPdf only adds a new order pdf based on Zend_Pdf and is not involved in the handling of packing slips. Not all PrintOrderPdf enabled installs would also have PdfCustomiser installed.

2.) PdfCustomiser comes with two modes to create a packing slip - either using the Magento Shipment as a source or to avoid the "Nothing to print" error when trying to print a packing slip before the shipment has been created using the Magento order as the source. This is based on the setting "Print Order as PackingSlip" (`sales_pdf/shipment/shipmentuseorder`) and would switch between `ShipmentFactory` and `OrderShipmentFactory`. I have updated the code to follow the same logic.

Longer term we could discuss moving some of this logic into our extension or an addon module with an aroundPlugin on `TIG\PostNL\Service\Shipment\Packingslip\Factory`. I'll ping you in the ExtDN slack.