### PR TITLE
RC version for Magento 2.2.10/2.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "require": {
         "php": "~7.0|~7.1|~7.2",
         "ext-soap": "*",
-        "magento/framework": ">=100.1.0,<=100.1.18|>=101.0.0,<=101.0.9|>=102.0.0,<=102.0.2",
+        "magento/framework": ">=100.1.0,<=100.1.18|>=101.0.0,<=101.0.10|>=102.0.0,<=102.0.3",
         "setasign/fpdi-fpdf": "2.1",
         "zendframework/zend-barcode" : "2.5.2|2.7"
     },
     "type": "magento2-module",
     "license": "CC-BY-NC-ND-3.0",
-    "version": "1.8.0",
+    "version": "1.9.0-RC1",
     "authors": [
         {
             "name": "TIG",


### PR DESCRIPTION
TIG PostNL has a hard requirement on Magento version 2.3.2 or less. In order to update to Magento 2.3.3 we need to change the requirements.