### PR TITLE
CSV Import Error - Update Tablerates Table

### DIFF
--- a/Setup/V110/Schema/InstallTablerateTable.php
+++ b/Setup/V110/Schema/InstallTablerateTable.php
@@ -49,7 +49,7 @@ class InstallTablerateTable extends AbstractTableInstaller
         $this->addText('dest_country_id', 'Destination coutry ISO/2 or ISO/3 code', 4, false, '0');
         $this->addInt('dest_region_id', 'Destination Region ID', false, true, 0);
         $this->addText('dest_zip', 'Destination Post Code (Zip)', 10, false, '*');
-        $this->addText('condition_name', 'Rate Condition name', 20, false);
+        $this->addText('condition_name', 'Rate Condition name', 30, false);
         $this->addDecimal('condition_value', 'Rate condition value', '12,4', false, '0.0000');
         $this->addDecimal('price', 'Price', '12,4', false, '0.0000');
         $this->addDecimal('cost', 'Cost', '12,4', false, '0.0000');

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="tig_postnl_tablerate">
+        <column xsi:type="varchar" name="condition_name" nullable="false" length="20" comment="Rate Condition name"/>
+        <column xsi:type="varchar" name="condition_name" nullable="false" length="30" comment="Rate Condition name"/>
+    </table>
+</schema>


### PR DESCRIPTION
When importing tablerates.csv (tablerates based on Price vs. Destination) an exception is thrown when value is already present in database.

The condition_name is 'package_value_with_discount' is too long for column length, so it saved as  'package_value_with_d'. A check for the condition_name would always return false.