### PR TITLE
Fix typo in set-billing-address mixin and add select-billing-address mixin

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -37,13 +37,16 @@ var config = {
             'Amasty_Checkout/js/action/set-shipping-information' : {
                 'TIG_PostNL/js/action/set-shipping-information-mixin': true
             },
-            'Magneto_Checkout/js/action/set-billing-address': {
-                'TIG_PostNL/js/action/set-billing-address': true
+            'Magento_Checkout/js/action/set-billing-address': {
+                'TIG_PostNL/js/action/set-billing-address-mixin': true
             },
             'Magento_Checkout/js/action/place-order': {
                 'TIG_PostNL/js/action/set-billing-address-mixin': true
             },
             'Magento_Checkout/js/action/create-billing-address': {
+                'TIG_PostNL/js/action/set-billing-address-mixin': true
+            },
+            'Magento_Checkout/js/action/select-billing-address': {
                 'TIG_PostNL/js/action/set-billing-address-mixin': true
             },
             'Magento_Checkout/js/action/set-payment-information': {


### PR DESCRIPTION
There's a typo in the `set-billing-address` mixin. Magento is typed as Magneto. Also the mixin for `select-billing-address` is missing. This causes issues with the `Afterpay (old)` method that the extension attributes in the billing address are unknown.