### PR TITLE
Fixed the name of the Proxy class used for Fooman PdfCustomiser compatibility

### DIFF
--- a/Service/Shipment/Packingslip/Compatibility/ShipmentFactoryProxy.php
+++ b/Service/Shipment/Packingslip/Compatibility/ShipmentFactoryProxy.php
@@ -61,7 +61,7 @@ class ShipmentFactoryProxy
     private function getSubject()
     {
         if (!$this->subject) {
-            $this->subject = $this->objectManager->get(\Fooman\PdfCustomiser\Block\ShipmentFactoryProxy::class);
+            $this->subject = $this->objectManager->get(\Fooman\PdfCustomiser\Block\ShipmentFactory\Proxy::class);
         }
         return $this->subject;
     }


### PR DESCRIPTION
A proxy class should be called \Original\Class\Name\Proxy, not \Original\Class\NameProxy. 

This PR fixes #139 