### PR TITLE
Fix for having multiple "from" email addresses for multiple store views in track and trace emails

### DIFF
--- a/Helper/Tracking/Mail.php
+++ b/Helper/Tracking/Mail.php
@@ -136,9 +136,11 @@ class Mail extends AbstractTracking
             $this->getTemplateVars($order, $url)
         );
 
-        $transport->setFrom('general');
+        
         if (method_exists($transport, 'setFromByScope')) {
             $transport->setFromByScope('general', $shipment->getStoreId());
+        } else {
+            $transport->setFrom('general');   
         }
 
         $address = $shipment->getShippingAddress();


### PR DESCRIPTION
When there are multiple storeviews and a track and trace mail is being sent, it puts the general email first and then adds the email of the scoped store. This will fix that issue.