### PR TITLE
Selected preferred delivery date is overwritten by setDefaultData

### DIFF
--- a/Observer/TIGPostNLOrderSaveBefore/SetDefaultData.php
+++ b/Observer/TIGPostNLOrderSaveBefore/SetDefaultData.php
@@ -156,9 +156,11 @@ class SetDefaultData implements ObserverInterface
         if (!$order->getShippingDuration()) {
             $order->setShippingDuration($duration);
         }
-
-        $this->firstDeliveryDate->set($order);
-
+	    
+	if (!$order->getDeliveryDate()) {
+            $this->firstDeliveryDate->set($order);
+	}
+	    
         // As long as the Magento Order is not saved the ship at is not determined.
         if (!$order->getShipAt() || !$order->getOrderId()) {
             $this->shipAt->set($order);


### PR DESCRIPTION
The date that is posted in the ajax save in the checkout (postnl/deliveryoptions/save/) is overwritten by the setDefaultData observer. In our case this causes the dates to be set to the first available delivery date instead of the selected delivery date (further into the future) in the checkout. 

No time to test on default Magento and to test other cases. So this is just a quick fix that i want to share.