### PR TITLE
Changed default value of postnl_disable_delivery_days

### DIFF
--- a/Setup/V191/Data/InstallDisableDeliveryDaysAttribute.php
+++ b/Setup/V191/Data/InstallDisableDeliveryDaysAttribute.php
@@ -86,7 +86,7 @@ class InstallDisableDeliveryDaysAttribute extends AbstractDataInstaller
                 'visible'                 => true,
                 'required'                => false,
                 'user_defined'            => false,
-                'default'                 => '1',
+                'default'                 => '0',
                 'searchable'              => false,
                 'filterable'              => false,
                 'comparable'              => false,


### PR DESCRIPTION
If you create or update a product via the webapi without sending data for this new attribuut the value will be updated to 1 which undesirably disables the delivery dates option in the checkout