### PR TITLE
dataHelper is no factory, fix error

### DIFF
--- a/Service/Shipment/Packingslip/Compatibility/XtentoPdfCustomizer.php
+++ b/Service/Shipment/Packingslip/Compatibility/XtentoPdfCustomizer.php
@@ -83,11 +83,11 @@ class XtentoPdfCustomizer
         $orderId = $magentoShipment->getOrderId();
         $order = $this->orderRepository->get($orderId);
 
-        $xtentoDataHelper = $this->dataHelper->create();
+        $xtentoDataHelper = $this->dataHelper;
         $template = $xtentoDataHelper->getDefaultTemplate($order, TemplateType::TYPE_SHIPMENT);
         $templateId = $template->getId();
 
-        $generatePdfHelper = $this->pdfGenerator->create();
+        $generatePdfHelper = $this->pdfGenerator;
         $document = $generatePdfHelper->generatePdfForObject('shipment', $magentoShipment->getId(), $templateId);
 
         return $document['output'];
@@ -98,7 +98,7 @@ class XtentoPdfCustomizer
      */
     public function isShipmentPdfEnabled()
     {
-        $xtentoDataHelper = $this->dataHelper->create();
+        $xtentoDataHelper = $this->dataHelper;
 
         if ($xtentoDataHelper->isEnabled(Data::ENABLE_SHIPMENT)) {
             return true;


### PR DESCRIPTION
Error:

19-Jun-2020 04:40:00 UTC] PHP Fatal error:  Uncaught Error: Call to undefined method Xtento\PdfCustomizer\Helper\Data::create() in /home/xxxxx/public_html/vendor/tig/postnl-magento2/Service/Shipment/Packingslip/Compatibility/DataHelperFactoryProxy.php:79
Stack trace:
#0 /home/xxxxx/public_html/vendor/tig/postnl-magento2/Service/Shipment/Packingslip/Compatibility/XtentoPdfCustomizer.php(101): TIG\PostNL\Service\Shipment\Packingslip\Compatibility\DataHelperFactoryProxy->create()
#1 /home/xxxxx/public_html/vendor/tig/postnl-magento2/Service/Shipment/Packingslip/Factory.php(107): TIG\PostNL\Service\Shipment\Packingslip\Compatibility\XtentoPdfCustomizer->isShipmentPdfEnabled()
#2 /home/xxxxx/public_html/vendor/tig/postnl-magento2/Service/Shipment/Packingslip/GetPackingslip.php(106): TIG\PostNL\Service\Shipment\Packingslip\Factory->create(Object(Magento\Sales\Model\Order\Shipment))
#3 /home/xxxxx/public_html/vendor/tig/postnl-magento2/Controller/Adminhtml/LabelAbstract.php(139): TIG\PostNL\Service\Shipment\Packingslip\GetPackingslip->get('711699', true, in /home/xxxxx/public_html/vendor/tig/postnl-magento2/Service/Shipment/Packingslip/Compatibility/DataHelperFactoryProxy.php on line 79

This pull request fixes the error. The data helper is no factory, so no create call is required. Same for the generate helper.