### PR TITLE
[BUGFIX] Fix checkout error when JS minification is active

### DIFF
--- a/view/frontend/web/js/view/shipping-mixin.js
+++ b/view/frontend/web/js/view/shipping-mixin.js
@@ -77,7 +77,7 @@ define([
 
                 if (checkedOption === undefined) {
                     this.errorValidationMessage(
-                        $t("Please select a PostNL delivery option before continuing. If no options are visible, please make sure you've entered your address information correctly.")
+                        $t('Please select a PostNL delivery option before continuing. If no options are visible, please make sure you\'ve entered your address information correctly.')
                     );
 
                     return false;


### PR DESCRIPTION
When JS minification is enabled and you go to checkout, shipping step, and the default country is not NL or BE, checkout is not loaded entirely as a JS error stops it:
https://prnt.sc/zveruw > https://prnt.sc/zvet3b 