### PR TITLE
[BUGFIX] Fix for async plugin when order is not shipped with PostNL

### DIFF
--- a/Plugin/Order/AsyncPlugin.php
+++ b/Plugin/Order/AsyncPlugin.php
@@ -108,6 +108,9 @@ class AsyncPlugin extends Grid
     {
         foreach ($this->notSyncedIds as $orderId) {
             $postNLOrder = $this->orderRepository->getByOrderId($orderId);
+            if (!$postNLOrder) {
+                continue;
+            }
             $shipAt = $postNLOrder->getShipAt();
             $productCode = $postNLOrder->getProductCode();
             $confirmed = $postNLOrder->getConfirmed();

--- a/Plugin/Shipment/AsyncPlugin.php
+++ b/Plugin/Shipment/AsyncPlugin.php
@@ -108,7 +108,9 @@ class AsyncPlugin extends Grid
     {
         foreach ($this->notSyncedIds as $shipmentId) {
             $postNLShipment = $this->shipmentRepository->getByShipmentId($shipmentId);
-
+            if (!$postNLShipment) {
+                continue;
+            }
             $connection = $this->resourceConnection->getConnection();
 
             $binds = [


### PR DESCRIPTION
Magento version: 2.3.5-p2
TIG_PostNL version: 1.9.5

This PR solves a problem when the orders are synchronized to the order grid if the order doesn't use PostNL and therefore can't be found.

`\TIG\PostNL\Model\ShipmentRepository::getByShipmentId` and `\TIG\PostNL\Model\OrderRepository::getByOrderId` can return null. This is causing an error for some orders:

```
report.CRITICAL: Error when running a cron job {"exception":"[object] (RuntimeException(code: 0): Error when running a cron job at vendor/magento/module-cron/Observer/ProcessCronQueueObserver.php:362, Error(code: 0): Call to a member function getShipAt() on null at vendor/tig/postnl-magento2/Plugin/Order/AsyncPlugin.php:111)"} []
```
