### PR TITLE
+ Replace getCustomAttribute with getData to increace preformance

### DIFF
--- a/Service/Options/ProductDictionary.php
+++ b/Service/Options/ProductDictionary.php
@@ -76,14 +76,14 @@ class ProductDictionary
     {
         $products = $this->collectionByItems->get($items);
         return array_filter($products, function (ProductInterface $product) use ($postNLTypes, $convertLetterbox) {
-            $attribute = $product->getCustomAttribute(PostNLType::POSTNL_PRODUCT_TYPE);
+            $attribute = $product->getData(PostNLType::POSTNL_PRODUCT_TYPE);
             if ($convertLetterbox &&
                 $attribute &&
-                $attribute->getValue() == PostNLType::PRODUCT_TYPE_LETTERBOX_PACKAGE
+                $attribute == PostNLType::PRODUCT_TYPE_LETTERBOX_PACKAGE
             ) {
                 $attribute->setValue(PostNLType::PRODUCT_TYPE_REGULAR);
             }
-            $value = $attribute !== null ? $attribute->getValue() : false;
+            $value = $attribute !== null ? $attribute : false;
             return in_array($value, $postNLTypes);
         });
     }

--- a/Service/Parcel/CountAbstract.php
+++ b/Service/Parcel/CountAbstract.php
@@ -203,9 +203,9 @@ abstract class CountAbstract extends CollectAbstract
 
         /** @var ProductInterface $product */
         $product            = $this->products[$item->getId()];
-        $productParcelCount = $product->getCustomAttribute(self::ATTRIBUTE_PARCEL_COUNT);
+        $productParcelCount = $product->getData(self::ATTRIBUTE_PARCEL_COUNT);
         if ($productParcelCount) {
-            return ($productParcelCount->getValue() * $this->quantities[$item->getId()]);
+            return ($productParcelCount * $this->quantities[$item->getId()]);
         }
 
         return 0;

--- a/Service/Product/CollectionByAttributeValue.php
+++ b/Service/Product/CollectionByAttributeValue.php
@@ -72,8 +72,8 @@ class CollectionByAttributeValue
     {
         $products = $this->collectionByItems->get($items);
         return array_filter($products, function (ProductInterface $product) use ($code, $matchedValue) {
-            $attribute = $product->getCustomAttribute($code);
-            $value = $attribute !== null ? $attribute->getValue() : false;
+            $attribute = $product->getData($code);
+            $value = $attribute !== null ? $attribute : false;
             return in_array($value, $matchedValue);
         });
     }
@@ -92,8 +92,8 @@ class CollectionByAttributeValue
     {
         $products = $this->collectionByItems->get($items);
         return array_filter($products, function (ProductInterface $product) use ($code, $minValue) {
-            $attribute = $product->getCustomAttribute($code);
-            $value = $attribute !== null ? $attribute->getValue() : false;
+            $attribute = $product->getData($code);
+            $value = $attribute !== null ? $attribute : false;
             return ($value > $minValue);
         });
     }

--- a/Service/Quote/ShippingDuration.php
+++ b/Service/Quote/ShippingDuration.php
@@ -99,11 +99,11 @@ class ShippingDuration
         $products = $this->productCollection->getByIds($quote->getAllItems());
 
         $shippingDurations = array_map(function (ProductInterface $product) {
-            $attribute = $product->getCustomAttribute(static::ATTRIBUTE_CODE);
-            if (!$attribute) {
+            $attribute = $product->getData(static::ATTRIBUTE_CODE);
+            if (!isset($attribute)) {
                 return $this->webshopConfiguration->getShippingDuration();
             }
-            return $attribute->getValue();
+            return $attribute;
         }, $products);
 
         $itemsDuration = $this->getItemsDuration($shippingDurations);

--- a/Service/Volume/CalculateAbstract.php
+++ b/Service/Volume/CalculateAbstract.php
@@ -99,8 +99,8 @@ abstract class CalculateAbstract
 
         /** @var ProductInterface $product */
         $product = $products[$productId];
-        $productVolume = $product->getCustomAttribute(static::ATTRIBUTE_VOLUME);
-        return ($productVolume->getValue() * $this->getQty($item));
+        $productVolume = $product->getData(static::ATTRIBUTE_VOLUME);
+        return ($productVolume * $this->getQty($item));
     }
 
     /**


### PR DESCRIPTION
The `getCustomAttribute()` function has a negative impact on performance. 
Replacing the function with `getData()` gives a big performance boost, without changing any of the functionality 

https://www.integer-net.com/performance-trap-magento-2-getcustomattribute-function/