### PR TITLE
AddressHelper when street lines are < 2

### DIFF
--- a/view/frontend/web/js/Helper/AddressFinder.js
+++ b/view/frontend/web/js/Helper/AddressFinder.js
@@ -96,19 +96,24 @@ define([
             RegistryFields.push('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.postcode-field-group.field-group.housenumber');
         } else {
             RegistryFields.push('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.postcode');
-            RegistryFields.push('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.street.1');
+            uiRegistry.get('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.street.1', function (houseNumberField) {
+                address.housenumber = houseNumberField.value();
+            });
         }
 
-        uiRegistry.get(RegistryFields, function (firstnameField, lastnameField, streetFirstLine, postcodeField, houseNumberField) {
-            // The housenumber value could be empty, and could have been included in the first address line.
-            var housenumber = houseNumberField.value();
-            if (!housenumber && streetFirstLine.value() !== undefined) {
-                housenumber = streetFirstLine.value().replace(/\D/g,'');
+        uiRegistry.get(RegistryFields, function (firstnameField, lastnameField, streetFirstLine, postcodeField) {
+            var street = streetFirstLine.value();
+            if (!address.housenumber && streetFirstLine.value() !== undefined) {
+                address.housenumber = streetFirstLine.value().replace(/\D/g,'');
+
             }
 
-            address.street = [streetFirstLine.value()];
+            if (address.housenumber) {
+                street = streetFirstLine.value().split(address.housenumber)[0].trim();
+            }
+
+            address.street = [street];
             address.postcode = postcodeField.value();
-            address.housenumber = housenumber;
             address.firstname = firstnameField.value();
             address.lastname = lastnameField.value();
         });


### PR DESCRIPTION
Hey there,

We've experienced a bug with this version of the PostNL module in combination with Magento 2.3.6-p1 regarding our customers that have configured their checkout to only have one street line as is possible in Stores > Configuration > Customers > Customer Configuration > Name and Address Options > Number of lines in a Street Address. In those cases there is no checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.street.1 field in the uiRegistry which causes the large uiRegistry.get call to not trigger and therefor the address to not be filled.

We've managed to fix this by adding the housenumber seperatly (as you've already done for some other fields) and then checking for the existence of the house number in the large uiRegistry field. We've also decided to fitler the housenumber from the street because that seemed to cause some issues in some specific cases. This might not be necessary.