### PR TITLE
[BUGFIX] - Refactored fallback delivery date calculation.

### DIFF
--- a/Webservices/Api/DeliveryDateFallback.php
+++ b/Webservices/Api/DeliveryDateFallback.php
@@ -70,7 +70,7 @@ class DeliveryDateFallback
         }
 
         $date = $this->getDate($nextDay);
-        while (!in_array(date('N', strtotime($date)), $shippingDays)) {
+        while (!in_array(date('N', strtotime($date)), $shippingDays) && count($shippingDays)) {
             $date = $this->getDate($date . '+1 day');
         }
 

--- a/Webservices/Api/DeliveryDateFallback.php
+++ b/Webservices/Api/DeliveryDateFallback.php
@@ -64,25 +64,19 @@ class DeliveryDateFallback
     public function get()
     {
         $shippingDays = explode(',', $this->webshop->getShipmentDays());
-        $nextDay      = '+1 day';
+        $nextDay = '+1 day';
         if ($this->isPastCutOff->calculate()) {
             $nextDay = '+2 day';
         }
 
         $date = $this->getDate($nextDay);
-        $day  = $this->helper->getDayOrWeekNumber($nextDay);
-        if ($day == 7) {
-            $nextDay = $date .'+1 day';
+        while (!in_array(date('N', $date), $shippingDays)) {
+            $date->modify('+1 day');
         }
 
-        $day = $this->helper->getDayOrWeekNumber($nextDay);
-        if ($day == 1 && !in_array(0, $shippingDays)) {
-            $nextDay = $date. '+2 day';
-        }
-
-        return $this->getDate($nextDay);
+        return $this->getDate($date);
     }
-
+    
     /**
      * @param $day
      * @return string

--- a/Webservices/Api/DeliveryDateFallback.php
+++ b/Webservices/Api/DeliveryDateFallback.php
@@ -70,8 +70,8 @@ class DeliveryDateFallback
         }
 
         $date = $this->getDate($nextDay);
-        while (!in_array(date('N', $date), $shippingDays)) {
-            $date->modify('+1 day');
+        while (!in_array(date('N', strtotime($date)), $shippingDays)) {
+            $date = $this->getDate($date . '+1 day');
         }
 
         return $this->getDate($date);


### PR DESCRIPTION
The fallback delivery day calculation had some inconsistent choices.

In the first if statement, variable $day is compared to 7, to check if it's a Sunday. If so, move the delivery date to the following Monday.

This shouldn't be happening, because both Sunday and Saturday are valid shipping days in configuration. The fallback should depend on only those days to calculate its date.

After this, the second if statement checks if the current shipping date is a Monday, and if Sunday is not a shipping day, move the date back another day. This also shouldn't happen. Currently, any orders being made before the Sunday cutoff are being shipped on Tuesday, even if Monday is a valid shipping date, only because Sunday is not.

This commit changes the logic in the function, to allow the date to be calculated in a new way: Starting from the following day (plus another day if the order is placed after the cutoff time), set the shipping date to the first date which is a valid shipping day.