### PR TITLE
Get address fields by dataScope instead of name

### DIFF
--- a/view/frontend/web/js/Helper/AddressFinder.js
+++ b/view/frontend/web/js/Helper/AddressFinder.js
@@ -81,22 +81,24 @@ define([
         }
 
         // Country is required to determine which fields are used.
-        uiRegistry.get('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.country_id', function (countryField) {
+        uiRegistry.get('dataScope = shippingAddress.country_id', function (countryField) {
             address.country = countryField.value();
         });
 
         var RegistryFields = [
-            'checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.firstname',
-            'checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.lastname',
-            'checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.street.0'
+            'dataScope = shippingAddress.firstname',
+            'dataScope = shippingAddress.lastname',
+            'dataScope = shippingAddress.street.0'
         ];
 
-        if ((address.country === 'NL' && window.checkoutConfig.shipping.postnl.is_postcodecheck_active) || (window.checkoutConfig.postcode !== undefined && window.checkoutConfig.postcode.postcode_active)) {
-            RegistryFields.push('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.postcode-field-group.field-group.postcode');
-            RegistryFields.push('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.postcode-field-group.field-group.housenumber');
+        if ((address.country === 'NL' && window.checkoutConfig.shipping.postnl.is_postcodecheck_active)
+            || (window.checkoutConfig.postcode !== undefined && window.checkoutConfig.postcode.postcode_active)
+        ) {
+            RegistryFields.push('datascope = shippingAddress.postcode');
+            RegistryFields.push('dataScope = shippingAddress.custom_attributes.tig_housenumber');
         } else {
-            RegistryFields.push('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.postcode');
-            uiRegistry.get('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.street.1', function (houseNumberField) {
+            RegistryFields.push('dataScope = shippingAddress.postcode');
+            uiRegistry.get('dataScope = shippingAddress.street.1', function (houseNumberField) {
                 address.housenumber = houseNumberField.value();
             });
         }
@@ -118,7 +120,7 @@ define([
         });
 
         // Some merchants disable the telephone field. Adding this to the previous part will stop the entire get function
-        uiRegistry.get('checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.telephone', function (telephoneField) {
+        uiRegistry.get('dataScope = shippingAddress.telephone', function (telephoneField) {
             address.telephone = telephoneField.value();
         });
 


### PR DESCRIPTION
After updating to version 1.9.7 or higher, timeframes and locations aren't loading anymore for guest customers, because we've moved (re-ordered and re-grouped) address fields in the checkout (for multiple clients). Turns out this is happening because from version 1.9.7 the address fields are retrieved by name. These names are very specific and will change when a field is moved. The dataScope however should stay the same, therefore it would be more reliable and flexible to use this to get the fields.