### PR TITLE
 dont query order repository without quote_id when order_id is null

### DIFF
--- a/Model/OrderRepository.php
+++ b/Model/OrderRepository.php
@@ -201,6 +201,10 @@ class OrderRepository extends AbstractRepository implements OrderRepositoryInter
             $quoteId = $this->quoteWrapper->getQuoteId();
         }
 
+        if ($quoteId === null) {
+            return null;
+        }
+        
         $filter = $this->filterBuilder->setField('quote_id');
         $filter->setValue($quoteId);
         $this->searchCriteriaBuilder->addFilters([$filter->create()]);


### PR DESCRIPTION
Don't Query Order Repository when both orderId and quoteId is null.