### PR TITLE
Do not change return type address total plugin

### DIFF
--- a/Plugin/Quote/Address/Total/Shipping.php
+++ b/Plugin/Quote/Address/Total/Shipping.php
@@ -84,14 +84,14 @@ class Shipping
         Quote\Address\Total $total
     ) {
         $this->subject = $subject;
-        $proceed($quote, $shippingAssignment, $total);
+        $return = $proceed($quote, $shippingAssignment, $total);
 
         $shipping = $shippingAssignment->getShipping();
         $address = $shipping->getAddress();
         $rate = $this->getRate($shipping->getMethod(), $address);
 
         if (!$rate) {
-            return $this;
+            return $return;
         }
 
         $this->processTotal($quote, $total, $rate, $address);


### PR DESCRIPTION
Unable to create after plugin on `Magento\Quote\Model\Quote\Address\Total\Shipping::collect()` because return type is changed.

```
Argument 2 passed afterCollect() must be an instance of Magento\Quote\Model\Quote\Address\Total\Shipping, instance of TIG\PostNL\Plugin\Quote\Address\Total\Shipping given.
```