### PR TITLE
Cast getFreeShipping value to boolean

### DIFF
--- a/Service/Carrier/Price/Calculator.php
+++ b/Service/Carrier/Price/Calculator.php
@@ -124,7 +124,7 @@ class Calculator
     {
         $this->store = $store;
 
-        if ($request->getFreeShipping() === true || $request->getPackageQty() == $this->getFreeBoxes->get($request)) {
+        if ((bool)$request->getFreeShipping() === true || $request->getPackageQty() == $this->getFreeBoxes->get($request)) {
             return $this->priceResponse('0.00', '0.00');
         }
 
@@ -162,7 +162,7 @@ class Calculator
             }
         }
 
-        if ($request->getFreeShipping() === true || $request->getPackageQty() == $this->getFreeBoxes->get($request)) {
+        if ((bool)$request->getFreeShipping() === true || $request->getPackageQty() == $this->getFreeBoxes->get($request)) {
             $rateType = 'free';
         }
 


### PR DESCRIPTION
Magento sets this value as an integer since this change: https://github.com/magento/magento2/commit/bd149447d03f30dfd7cbda19c28a8140a87e0c9f

a strict comparison with true therefore always results in a false result, even when free shipping is set as 1. 

Since we don't know if there is other code that does set this value to true this change seemed to be the most backwards compatible solution. You could also choose to do a non-strict comparison (==), but the cast seemed a bit more explicit.