### PR TITLE
Fix php 8.1 error

### DIFF
--- a/Observer/SalesOrderSaveAfter/AddressToOrder.php
+++ b/Observer/SalesOrderSaveAfter/AddressToOrder.php
@@ -122,7 +122,7 @@ class AddressToOrder implements ObserverInterface
 
         if ($quotePgAddress->getTelephone() === null) {
             $billingAddress = $order->getBillingAddress();
-            $quotePgAddress->setTelephone($billingAddress->getTelephone());
+            $quotePgAddress->setTelephone($billingAddress->getTelephone() ?? '');
         }
 
         if ($quotePgAddress->getId() && $this->shouldAdd($order, $postnlOrder)) {


### PR DESCRIPTION
In order to prevent php 8.1 error further down the line:

```
Exception: Deprecated Functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/boxers/releases/9/vendor/magento/module-sales/Model/Order/Address.php on line 604 in /home/boxers/releases/9/vendor/magento/framework/App/ErrorHandler.php:61 Stack trace: #0 /home/boxers/releases/9/vendor/sentry/sentry/src/ErrorHandler.php(305): Magento\Framework\App\ErrorHandler->handler(8192, 'trim(): Passing...', '/home/boxers/re...', 604, Array) #1 [internal function]: Sentry\ErrorHandler->handleError(8192, 'trim(): Passing...', '/home/boxers/re...', 604) #2 /home/boxers/releases/9/vendor/magento/module-sales/Model/Order/Address.php(604): trim(NULL) #3 /home/boxers/releases/9/vendor/tig/postnl-magento2/Observer/SalesOrderSaveAfter/AddressToOrder.php(239): 
```