### PR TITLE
Remove hard laminas-mime references for PHP 8.4 compatibility

### DIFF
--- a/Controller/Adminhtml/Order/Email.php
+++ b/Controller/Adminhtml/Order/Email.php
@@ -2,7 +2,6 @@
 
 namespace TIG\PostNL\Controller\Adminhtml\Order;
 
-use Laminas\Mime\Mime;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\LocalizedException;

--- a/Model/Mail/Template/TransportBuilder.php
+++ b/Model/Mail/Template/TransportBuilder.php
@@ -54,9 +54,9 @@ class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
      */
     private function createMimePart(
         $content,
-        string $type        = \Laminas\Mime\Mime::TYPE_OCTETSTREAM,
-        string $disposition = \Laminas\Mime\Mime::DISPOSITION_ATTACHMENT,
-        string $encoding    = \Laminas\Mime\Mime::ENCODING_BASE64,
+        string $type        = 'application/octet-stream',
+        string $disposition = 'attachment',
+        string $encoding    = 'base64',
         $filename           = null
     ) {
         $mimePart = new \Laminas\Mime\Part($content);
@@ -100,8 +100,8 @@ class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
                 if ($body) {
                     $mimePart = $this->createMimePart(
                         (string)$body,
-                        \Laminas\Mime\Mime::TYPE_TEXT,
-                        \Laminas\Mime\Mime::DISPOSITION_INLINE
+                        'text/plain',
+                        'inline'
                     );
                     $mimeMessage->setParts([$mimePart]);
                 }


### PR DESCRIPTION
On Magento 2.4.9 / PHP 8.4 there's no installable laminas-mime anymore, but `createMimePart()`'s default params and an unused import still hard-reference it. Swapped those for the indentical literal strings, the legacy laminas path stays untouched.