### PR TITLE
Cast order fee to float with default value

### DIFF
--- a/Plugin/Quote/Address/Total/Shipping.php
+++ b/Plugin/Quote/Address/Total/Shipping.php
@@ -113,6 +113,6 @@ class Shipping
             return 0;
         }
 
-        return $order->getFee();
+        return (float)($order->getFee() ?? 0);
     }
 }


### PR DESCRIPTION
## Summary

Hotfix for a TIG PostNL TypeError.

When a PostNL order record existed for a quote but the fee value was `null`, the `getFee()` method returned `null` while its return type requires `float|int`. This caused cart/totals collection to fail.

## Changes

- Added a safe fallback in `getFee()`
- Return `0.0` when the PostNL fee is missing or null

## Testing

- Verified cart totals can be collected without errors
- Verified cart item removal works again

## Actual error

- [2026-07-21T09:13:38.671687+00:00] main.CRITICAL: TypeError: TIG\PostNL\Plugin\Quote\Address\Total\Shipping::getFee(): Return value must be of type int|float, null returned in /data/web/magento2/releases/221/vendor/tig/postnl-magento2/Plugin/Quote/Address/Total/Shipping.php:116